### PR TITLE
Composer outside control

### DIFF
--- a/DemoApp/DemoApp/Demos/Complex Tweet Demo/TweetComposerViewController.swift
+++ b/DemoApp/DemoApp/Demos/Complex Tweet Demo/TweetComposerViewController.swift
@@ -134,12 +134,21 @@ extension TweetComposerViewController: TWTRComposerViewControllerDelegate {
     }
 
     func composerDidFail(_ controller: TWTRComposerViewController, withError error: Error) {
-        dismiss(animated: false, completion: nil)
+        DispatchQueue.main.async {
+            self.dismiss(animated: false, completion: nil)
+        }
     }
 
     func composerDidSucceed(_ controller: TWTRComposerViewController, with tweet: TWTRTweet) {
-        dismiss(animated: false, completion: nil)
+        DispatchQueue.main.async {
+            self.dismiss(animated: false, completion: nil)
+        }
     }
+    
+    func composerCanControlOutside(_ controller: TWTRComposerViewController, completion: @escaping (Bool) -> Void) -> Bool {
+        return false
+    }
+
 }
 
 // MARK: - UIImagePickerControllerDelegate
@@ -151,12 +160,18 @@ extension TweetComposerViewController: UIImagePickerControllerDelegate, UINaviga
         }
     }
 
-    private func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         picker.dismiss(animated: true)
-        if let image = info[UIImagePickerController.InfoKey.originalImage.rawValue] as? UIImage {
+
+        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
             let composer = TWTRComposerViewController(initialText: "Check out this great image: ", image: image, videoURL: nil)
             composer.delegate = self
             self.present(composer, animated: true)
+        } else if let url = info[UIImagePickerController.InfoKey.mediaURL] as? NSURL {
+            let composer = TWTRComposerViewController(initialText: "Check out this great media: ", image: nil, videoURL: url as URL)
+            composer.delegate = self
+            self.present(composer, animated: true)
         }
+        
     }
 }

--- a/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRComposerViewController.h
+++ b/TwitterKit/TwitterKit/Social/Syndication/Controllers/TWTRComposerViewController.h
@@ -98,6 +98,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)composerDidFail:(TWTRComposerViewController *)controller withError:(NSError *)error;
 
+/**
+* This method is called if we want to send twit outside.
+* We need to call completion block to finish work with composer.
+*/
+- (BOOL)composerCanControlOutside:(TWTRComposerViewController *)controller completion:(void(^)(BOOL))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/TwitterKit/TwitterKit/TWTRSharedComposerWrapper.m
+++ b/TwitterKit/TwitterKit/TWTRSharedComposerWrapper.m
@@ -155,6 +155,16 @@ UIImage *videoThumbnail(NSURL *url)
 
 #pragma mark - TWTRSETweetShareViewControllerDelegate Protocol Methods
 
+- (BOOL)canControlOutsideWithCompletion:(void(^)(BOOL))completion
+{
+    if ([self.delegate respondsToSelector:@selector(composerCanControlOutside:completion:)]) {
+        BOOL canControlOutside = [self.delegate composerCanControlOutside:(TWTRComposerViewController *)self completion:completion];
+        return canControlOutside;
+    }
+    
+    return false;
+}
+
 - (void)shareViewControllerWantsToCancelComposerWithPartiallyComposedTweet:(nonnull TWTRSETweet *)partiallyComposedTweet
 {
     [self dismissViewControllerAnimated:YES completion:nil];

--- a/TwitterKit/TwitterKit/TwitterShareExtensionUI/Public/TWTRSETweetShareViewControllerDelegate.h
+++ b/TwitterKit/TwitterKit/TwitterShareExtensionUI/Public/TWTRSETweetShareViewControllerDelegate.h
@@ -63,6 +63,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)shareViewControllerDidSelectAccount:(id<TWTRSEAccount>)account;
 
+/**
+Control UI behaviour of composer outside.
+*/
+- (BOOL)canControlOutsideWithCompletion:(void(^)(BOOL))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/TwitterKitSOF.podspec
+++ b/TwitterKitSOF.podspec
@@ -1,13 +1,12 @@
 Pod::Spec.new do |s|
-  s.name = "TwitterKit5"
-  s.version = "5.0.3"
+  s.name = "TwitterKitSOF"
+  s.version = "5.0.4"
   s.summary = "Increase user engagement and app growth."
-  s.homepage = "https://github.com/touren/twitter-kit-ios"
-  s.documentation_url = "https://github.com/touren/twitter-kit-ios/wiki"
-  s.social_media_url = "https://taoren.me"
-  s.authors = "Tao Ren"
+  s.homepage = "https://github.com/N1k1tung/twitter-kit-ios"
+  s.documentation_url = "https://github.com/N1k1tung/twitter-kit-ios/wiki"
+  s.authors = "Tao Ren, Nikita Rodin"
   s.platform = :ios, "9.0"
-  s.source = { :http => "https://github.com/touren/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
+  s.source = { :http => "https://github.com/N1k1tung/twitter-kit-ios/releases/download/v#{s.version}/TwitterKit.zip" }
   s.vendored_frameworks = "iOS/TwitterKit.framework"
   s.license = { :type => "Commercial", :text => "Twitter Kit: Copyright Twitter, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Twitter Kit Agreement located at https://dev.twitter.com/overview/terms/twitterkit and the Developer Agreement located at https://dev.twitter.com/overview/terms/agreement. OSS: https://github.com/twitter/twitter-kit-ios/blob/master/OS_LICENSES.md"}
   s.resources = ["iOS/TwitterKit.framework/TwitterKitResources.bundle", "iOS/TwitterKit.framework/TwitterShareExtensionUIResources.bundle"]

--- a/TwitterKitSOF.podspec
+++ b/TwitterKitSOF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "TwitterKitSOF"
-  s.version = "5.0.4"
+  s.version = "5.0.5"
   s.summary = "Increase user engagement and app growth."
   s.homepage = "https://github.com/N1k1tung/twitter-kit-ios"
   s.documentation_url = "https://github.com/N1k1tung/twitter-kit-ios/wiki"

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-## Build TwitterKit.framework - x86_64
+## Build TwitterKit.framework - i386, x86_64
 xcodebuild \
     -project TwitterKit/TwitterKit.xcodeproj \
-    -scheme TwitterKit -configuration Debug \
+    -scheme TwitterKit -configuration Release \
     -sdk "iphonesimulator" \
+    -destination 'platform=iOS Simulator,name=iPhone 11' ONLY_ACTIVE_ARCH=NO ARCHS="i386 x86_64" \
     HEADER_SEARCH_PATHS="$(pwd)/TwitterCore/iphonesimulator/Headers $(pwd)/TwitterCore/iphonesimulator/PrivateHeaders"  \
     CONFIGURATION_BUILD_DIR=./iphonesimulator \
     clean build
@@ -12,7 +13,7 @@ xcodebuild \
 ## Build TwitterKit.framework - armv7, arm64
 xcodebuild \
     -project TwitterKit/TwitterKit.xcodeproj \
-    -scheme TwitterKit -configuration Debug \
+    -scheme TwitterKit -configuration Release \
     -sdk "iphoneos" \
     HEADER_SEARCH_PATHS="$(pwd)/TwitterCore/iphoneos/Headers $(pwd)/TwitterCore/iphoneos/PrivateHeaders"  \
     CONFIGURATION_BUILD_DIR=./iphoneos \
@@ -29,3 +30,7 @@ lipo -archs iOS/TwitterKit.framework/TwitterKit
 rm TwitterKit.zip
 zip -r TwitterKit.zip iOS/*
 rm -rf iOS
+rm -rf TwitterCore/iphoneos
+rm -rf TwitterCore/iphonesimulator
+rm -rf TwitterKit/iphoneos
+rm -rf TwitterKit/iphonesimulator


### PR DESCRIPTION
Problem

TwitterFramework can't upload large files more than 5 mb
If file is less than 5 mb, framework shows composer for uploading file underhood.
There isn't ability show this composer for files if size is larger than 5mb, but upload file outside

Solution

There was added 

`composerCanControlOutside:completion` method into `TWTRComposerViewControllerDelegate` protocol. So we can control UI state of composer by 
`func composerCanControlOutside(_ controller: TWTRComposerViewController, completion: @escaping (Bool) -> Void) -> Bool {
        //call completion(true), when outside uploading large file will be finished or completion(false) if there was an error
        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
            completion(true)
        }
        return true
    }`

Result

There were added ability change UI state of composer outside and refactored uploading file(added chunks uploading)
